### PR TITLE
Fix error HumidAir.mixing humidity

### DIFF
--- a/pyfluids/humid_air/humid_air.py
+++ b/pyfluids/humid_air/humid_air.py
@@ -474,16 +474,12 @@ class HumidAir:
             ),
             InputHumidAir.humidity(
                 (
-                    first_specific_mass_flow * first.humidity
-                    + first_specific_mass_flow * first.humidity * second.humidity
-                    + second_specific_mass_flow * second.humidity
-                    + second_specific_mass_flow * first.humidity * second.humidity
+                    first_specific_mass_flow * first.humidity * (1 + second.humidity)
+                    + second_specific_mass_flow * second.humidity * (1 + first.humidity)
                 )
                 / (
-                    first_specific_mass_flow
-                    + first_specific_mass_flow * second.humidity
-                    + second_specific_mass_flow
-                    + second_specific_mass_flow * first.humidity
+                    first_specific_mass_flow * (1 + second.humidity)
+                    + second_specific_mass_flow * (1 + first.humidity)
                 )
             ),
         )

--- a/pyfluids/humid_air/humid_air.py
+++ b/pyfluids/humid_air/humid_air.py
@@ -475,9 +475,16 @@ class HumidAir:
             InputHumidAir.humidity(
                 (
                     first_specific_mass_flow * first.humidity
+                    + first_specific_mass_flow * first.humidity * second.humidity
                     + second_specific_mass_flow * second.humidity
+                    + second_specific_mass_flow * first.humidity * second.humidity
                 )
-                / (first_specific_mass_flow + second_specific_mass_flow)
+                / (
+                    first_specific_mass_flow
+                    + first_specific_mass_flow * second.humidity
+                    + second_specific_mass_flow
+                    + second_specific_mass_flow * first.humidity
+                )
             ),
         )
 

--- a/tests/humid_air/test_humid_air_processes.py
+++ b/tests/humid_air/test_humid_air_processes.py
@@ -392,5 +392,11 @@ class TestHumidAirProcesses:
         assert self.humid_air.mixing(1, first, 2, second) == self.humid_air.with_state(
             InputHumidAir.pressure(self.humid_air.pressure),
             InputHumidAir.enthalpy((1 * first.enthalpy + 2 * second.enthalpy) / 3),
-            InputHumidAir.humidity((1 * first.humidity + 2 * second.humidity) / 3),
+            InputHumidAir.humidity(
+                (
+                    1 * first.humidity * (1 + second.humidity)
+                    + 2 * second.humidity * (1 + first.humidity)
+                )
+                / (1 * (1 + second.humidity) + 2 * (1 + first.humidity))
+            ),
         )


### PR DESCRIPTION
Hi

I think I spotted an error in the HumidAir.mixing method. The humidity of the mix was calculated incorrectly.

Here is my derivation:
 
$$X = \frac{m_W}{m_{dA}}$$
$$= \frac{X_1 m_{dA1}+X_2 m_{dA2}}{m_{dA1}+m_{dA2}} $$
$$= \frac{X_1\frac{m_1}{1+X_1}+ X_2\frac{m_2}{1+X_2}}{\frac{m_1}{1+X_1}+\frac{m_2}{1+X_2}}$$
$$= \frac{X_1 m_1 (1+X_2)+ X_2 m_2 (1+X_1)}{m_1 (1+X_2) + m_2 (1+X_1)}$$

Luckily I implemented my own mixing function before finding this one. While checking my own, they always were just a bit off.
 
 Thanks for the great library!